### PR TITLE
fix: equalize trees in flat and hier case

### DIFF
--- a/src/employees/flatten-data.ts
+++ b/src/employees/flatten-data.ts
@@ -10,8 +10,7 @@ function flattenTree<T>(idField: string, parentField: string, childrenField: str
             const employee = { ...item };
             delete employee[childrenField];
             employee[parentField] = parentId;
-            let employeeSubTree = [employee, ...visitChildren(item[childrenField], item[idField])];
-            subTree = [...employeeSubTree, ...subTree];
+            subTree = [...subTree, employee, ...visitChildren(item[childrenField], item[idField])];
         }
         return subTree;
     }

--- a/test/employees/flatten-data.test.ts
+++ b/test/employees/flatten-data.test.ts
@@ -24,15 +24,25 @@ describe('flatten-data', () => {
     });
 
     it('flattens tree with multiple roots', () => {
-        const tree = [{
-            id: 1
-        }, {
-            id: 2,
-            reports: [{
-                id: 3
-            }]
-        }];
+        const tree = [
+            {
+                id: 1,
+                reports: [{
+                    id: 4,
+                    reports: [{
+                        id: 5
+                    }]
+                }]
+            },
+            {
+                id: 2,
+                reports: [{
+                    id: 3
+                }]
+            }
+        ];
 
-        expect(flattenData(tree)).toEqual([{"id": 2, "managerId": null}, {"id": 3, "managerId": 2}, {"id": 1, "managerId": null}]);
+
+        expect(flattenData(tree)).toEqual( [{"id": 1, "managerId": null}, {"id": 4, "managerId": 1}, {"id": 5, "managerId": 4}, {"id": 2, "managerId": null}, {"id": 3, "managerId": 2}]);
     });
 });


### PR DESCRIPTION
flattenData function scrambles the order of the node in the resulting array, thus when passed to treeview via flat binding the tree looks different than in with hier data, which is not good for tests.