### PR TITLE
fix: rxjs peer

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@angular/common": "12 - 14",
     "@angular/core": "12 - 14",
     "@angular/router": "12 - 14",
-    "rxjs": "^6.4.0"
+    "rxjs": "^6.0.0 || ^7.0.0"
   },
   "dependencies": {
     "tslib": "^2.3.1"


### PR DESCRIPTION
Extend rxjs peer dependency to include 6.x and 7.x